### PR TITLE
Tools to forward third-party log messages into apex/logrus

### DIFF
--- a/apex/forwarder.go
+++ b/apex/forwarder.go
@@ -1,0 +1,35 @@
+package apex_ecslogs
+
+import (
+	"github.com/apex/log"
+	"github.com/segmentio/ecs-logs-go/log"
+)
+
+type Forwarder struct {
+	Level  log.Level
+	Logger log.Interface
+}
+
+func (f *Forwarder) HandleEntry(entry log_ecslogs.Entry) error {
+	logger := f.Logger
+	if logger == nil {
+		logger = log.Log
+	}
+
+	msg := entry.Message
+
+	switch f.Level {
+	case log.DebugLevel:
+		logger.Debug(msg)
+	case log.InfoLevel:
+		logger.Info(msg)
+	case log.WarnLevel:
+		logger.Warn(msg)
+	case log.ErrorLevel:
+		logger.Error(msg)
+	case log.FatalLevel:
+		logger.Fatal(msg)
+	}
+
+	return nil
+}

--- a/log/logger.go
+++ b/log/logger.go
@@ -112,3 +112,9 @@ func makeEventData(entry Entry) (data ecslogs.EventData) {
 	}
 	return data
 }
+
+func InstallDefaultLogOutput(handler Handler) {
+	writer := NewWriter("", 0, handler)
+	log.SetFlags(0)
+	log.SetOutput(writer)
+}

--- a/logrus/forwarder.go
+++ b/logrus/forwarder.go
@@ -1,0 +1,37 @@
+package logrus_ecslogs
+
+import (
+	"github.com/Sirupsen/logrus"
+	"github.com/segmentio/ecs-logs-go/log"
+)
+
+type Forwarder struct {
+	Level  logrus.Level
+	Logger logrus.FieldLogger
+}
+
+func (f *Forwarder) HandleEntry(entry log_ecslogs.Entry) error {
+	logger := f.Logger
+	if logger == nil {
+		logger = logrus.StandardLogger()
+	}
+
+	msg := entry.Message
+
+	switch f.Level {
+	case logrus.DebugLevel:
+		logger.Debug(msg)
+	case logrus.InfoLevel:
+		logger.Info(msg)
+	case logrus.WarnLevel:
+		logger.Warn(msg)
+	case logrus.ErrorLevel:
+		logger.Error(msg)
+	case logrus.FatalLevel:
+		logger.Fatal(msg)
+	case logrus.PanicLevel:
+		logger.Panic(msg)
+	}
+
+	return nil
+}


### PR DESCRIPTION
```go
func main() {
	log_ecslogs.InstallDefaultLogOutput(&logrus_ecslogs.Forwarder{
		Level: logrus.InfoLevel,
	})

	log.Println("you got it")
	log.Println("no more trash in stdout")
}
```
```
time="2017-04-18T17:20:39-07:00" level=info msg="you got it" 
time="2017-04-18T17:20:39-07:00" level=info msg="no more trash in stdout" 
```
```go
func main() {
	log_ecslogs.InstallDefaultLogOutput(&apex_ecslogs.Forwarder{
		Level: apexlog.InfoLevel,
	})

	apexlog.SetHandler(json.Default)

	log.Println("you got it")
	log.Println("no more trash in stdout")
}
```
```
{"fields":{},"level":"info","timestamp":"2017-04-18T17:23:53.479003856-07:00","message":"you got it"}
{"fields":{},"level":"info","timestamp":"2017-04-18T17:23:53.479222786-07:00","message":"no more trash in stdout"}
```