### PR TITLE
Update sirupsen/logrus import

### DIFF
--- a/logrus/formatter.go
+++ b/logrus/formatter.go
@@ -3,8 +3,8 @@ package logrus_ecslogs
 import (
 	"bytes"
 
-	"github.com/Sirupsen/logrus"
 	"github.com/segmentio/ecs-logs-go"
+	"github.com/sirupsen/logrus"
 )
 
 type Config struct {
@@ -26,7 +26,7 @@ func (f formatter) Format(entry *logrus.Entry) (b []byte, err error) {
 	var source string
 
 	if f.FuncInfo != nil {
-		if pc, ok := ecslogs.GuessCaller(f.Depth, 10, "github.com/segmentio/ecs-logs", "github.com/Sirupsen/logrus"); ok {
+		if pc, ok := ecslogs.GuessCaller(f.Depth, 10, "github.com/segmentio/ecs-logs", "github.com/sirupsen/logrus"); ok {
 			if info, ok := f.FuncInfo(pc); ok {
 				source = info.String()
 			}

--- a/logrus/formatter_test.go
+++ b/logrus/formatter_test.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/Sirupsen/logrus"
 	"github.com/segmentio/ecs-logs-go"
+	"github.com/sirupsen/logrus"
 )
 
 func TestFormatter(t *testing.T) {


### PR DESCRIPTION
This is needed due to an unfortunate change to the upstream logrus
repository, explained here:
https://github.com/sirupsen/logrus/issues/570#issuecomment-313933276

This is a prerequisite for https://github.com/segmentio/kit/pull/46