### PR TITLE
feat(event): include original error for more context

### DIFF
--- a/event.go
+++ b/event.go
@@ -9,16 +9,18 @@ import (
 )
 
 type EventError struct {
-	Type  string      `json:"type,omitempty"`
-	Error string      `json:"error,omitempty"`
-	Errno int         `json:"errno,omitempty"`
-	Stack interface{} `json:"stack,omitempty"`
+	Type          string      `json:"type,omitempty"`
+	Error         string      `json:"error,omitempty"`
+	Errno         int         `json:"errno,omitempty"`
+	Stack         interface{} `json:"stack,omitempty"`
+	OriginalError error       `json:"origError,omitempty"`
 }
 
 func MakeEventError(err error) EventError {
 	e := EventError{
-		Type:  reflect.TypeOf(err).String(),
-		Error: err.Error(),
+		Type:          reflect.TypeOf(err).String(),
+		Error:         err.Error(),
+		OriginalError: err,
 	}
 
 	if errno, ok := err.(syscall.Errno); ok {

--- a/event_test.go
+++ b/event_test.go
@@ -1,12 +1,15 @@
 package ecslogs
 
 import (
+	"fmt"
 	"io"
 	"syscall"
 	"testing"
 )
 
 func TestEvent(t *testing.T) {
+	unserializable := make(chan int) // a value that cannot be JSON-marshalled to ensure failure doesn't break everything
+
 	tests := []struct {
 		e Event
 		s string
@@ -17,11 +20,15 @@ func TestEvent(t *testing.T) {
 		},
 		{
 			e: Eprintf(WARN, "an error was raised (%s)", syscall.Errno(2)),
-			s: `{"level":"WARN","time":"0001-01-01T00:00:00Z","info":{"errors":[{"type":"syscall.Errno","error":"no such file or directory","errno":2}]},"data":{},"message":"an error was raised (no such file or directory)"}`,
+			s: `{"level":"WARN","time":"0001-01-01T00:00:00Z","info":{"errors":[{"type":"syscall.Errno","error":"no such file or directory","errno":2,"origError":2}]},"data":{},"message":"an error was raised (no such file or directory)"}`,
 		},
 		{
 			e: Eprint(ERROR, "an error was raised:", io.EOF),
-			s: `{"level":"ERROR","time":"0001-01-01T00:00:00Z","info":{"errors":[{"type":"*errors.errorString","error":"EOF"}]},"data":{},"message":"an error was raised: EOF"}`,
+			s: `{"level":"ERROR","time":"0001-01-01T00:00:00Z","info":{"errors":[{"type":"*errors.errorString","error":"EOF","origError":{}}]},"data":{},"message":"an error was raised: EOF"}`,
+		},
+		{
+			e: Eprint(ERROR, "an error was raised:", fakeError{"fail", unserializable}), // value that cannot be JSON-marshalled
+			s: fmt.Sprintf(`{"level":"ERROR","time":"0001-01-01T00:00:00Z","info":{},"data":{},"message":"an error was raised: {fail %v}"}`, unserializable),
 		},
 	}
 
@@ -30,4 +37,13 @@ func TestEvent(t *testing.T) {
 			t.Errorf("\n- expected: %s\n- found:    %s", test.s, s)
 		}
 	}
+}
+
+type fakeError struct {
+	msg   string
+	value interface{}
+}
+
+func (e *fakeError) Error() string {
+	return e.msg
 }


### PR DESCRIPTION
This PR changes the encoding for errors to include the original error in order to see more context in the JSON-ified logs, especially for more complex errors like `pgx.Error`. The current implementation loses a lot of this context by only include the type and error message, so this hopes to remedy that.

~~I'm not sure if this could be a bad idea in the event of some error including fields that cannot be marshalled, but I suspect that's probably not very common.~~