### PR TITLE
Add optional max field length parameter to apex handler

### DIFF
--- a/apex/handler.go
+++ b/apex/handler.go
@@ -8,10 +8,10 @@ import (
 )
 
 type Config struct {
-	Output         io.Writer
-	Depth          int
-	FuncInfo       func(uintptr) (ecslogs.FuncInfo, bool)
-	MaxFieldLength int
+	Output      io.Writer
+	Depth       int
+	FuncInfo    func(uintptr) (ecslogs.FuncInfo, bool)
+	MaxFieldLen int
 }
 
 func NewHandler(w io.Writer) apex.Handler {
@@ -23,7 +23,7 @@ func NewHandlerWith(c Config) apex.Handler {
 
 	if c.FuncInfo == nil {
 		return apex.HandlerFunc(func(entry *apex.Entry) error {
-			return logger.Log(MakeEvent(entry, c.MaxFieldLength))
+			return logger.Log(MakeEvent(entry, c.MaxFieldLen))
 		})
 	}
 
@@ -36,7 +36,7 @@ func NewHandlerWith(c Config) apex.Handler {
 			}
 		}
 
-		return logger.Log(makeEvent(entry, source, c.MaxFieldLength))
+		return logger.Log(makeEvent(entry, source, c.MaxFieldLen))
 	})
 }
 

--- a/apex/handler_test.go
+++ b/apex/handler_test.go
@@ -47,7 +47,7 @@ func TestHandlerMaxFieldLength(t *testing.T) {
 	}
 
 	log.
-		WithField("hello", "world").
+		WithField("hello", 1234).
 		WithField("key", "01234567890123456789").
 		Info("abcdefghijklmnopqrstuvwxyz")
 
@@ -56,7 +56,7 @@ func TestHandlerMaxFieldLength(t *testing.T) {
 	// I wish we could make better testing here but the apex
 	// API doesn't let us mock the timestamp so we can't really
 	// predict what "time" is gonna be.
-	if !strings.HasPrefix(s, `{"level":"INFO","time":"`) || !strings.HasSuffix(s, `"info":{"source":"bytes/buffer.go:42:bytes.(*Buffer).String"},"data":{"hello":"world","key":"0123456789"},"message":"abcdefghij"}`) {
+	if !strings.HasPrefix(s, `{"level":"INFO","time":"`) || !strings.HasSuffix(s, `"info":{"source":"bytes/buffer.go:42:bytes.(*Buffer).String"},"data":{"hello":1234,"key":"0123456789"},"message":"abcdefghij"}`) {
 		t.Error("apex handler failed:", s)
 	}
 }

--- a/apex/handler_test.go
+++ b/apex/handler_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	apex "github.com/apex/log"
-	"github.com/segmentio/ecs-logs-go"
+	ecslogs "github.com/segmentio/ecs-logs-go"
 )
 
 func TestHandler(t *testing.T) {
@@ -31,6 +31,32 @@ func TestHandler(t *testing.T) {
 	// API doesn't let us mock the timestamp so we can't really
 	// predict what "time" is gonna be.
 	if !strings.HasPrefix(s, `{"level":"ERROR","time":"`) || !strings.HasSuffix(s, `"errors":[{"type":"*errors.errorString","error":"EOF","origError":{}}]},"data":{"hello":"world"},"message":"an error was raised (EOF)"}`) {
+		t.Error("apex handler failed:", s)
+	}
+}
+
+func TestHandlerMaxFieldLength(t *testing.T) {
+	buf := &bytes.Buffer{}
+	log := &apex.Logger{
+		Handler: NewHandlerWith(Config{
+			Output:         buf,
+			FuncInfo:       testFuncInfo,
+			MaxFieldLength: 10,
+		}),
+		Level: apex.DebugLevel,
+	}
+
+	log.
+		WithField("hello", "world").
+		WithField("key", "01234567890123456789").
+		Info("abcdefghijklmnopqrstuvwxyz")
+
+	s := strings.TrimSpace(buf.String())
+
+	// I wish we could make better testing here but the apex
+	// API doesn't let us mock the timestamp so we can't really
+	// predict what "time" is gonna be.
+	if !strings.HasPrefix(s, `{"level":"INFO","time":"`) || !strings.HasSuffix(s, `"info":{"source":"bytes/buffer.go:42:bytes.(*Buffer).String"},"data":{"hello":"world","key":"0123456789"},"message":"abcdefghij"}`) {
 		t.Error("apex handler failed:", s)
 	}
 }

--- a/apex/handler_test.go
+++ b/apex/handler_test.go
@@ -39,9 +39,9 @@ func TestHandlerMaxFieldLength(t *testing.T) {
 	buf := &bytes.Buffer{}
 	log := &apex.Logger{
 		Handler: NewHandlerWith(Config{
-			Output:         buf,
-			FuncInfo:       testFuncInfo,
-			MaxFieldLength: 10,
+			Output:      buf,
+			FuncInfo:    testFuncInfo,
+			MaxFieldLen: 10,
 		}),
 		Level: apex.DebugLevel,
 	}

--- a/apex/handler_test.go
+++ b/apex/handler_test.go
@@ -49,6 +49,10 @@ func TestHandlerMaxFieldLength(t *testing.T) {
 	log.
 		WithField("hello", 1234).
 		WithField("key", "01234567890123456789").
+		WithField("long-map", map[string]string{
+			"key1": "a long value",
+			"key2": "another long value",
+		}).
 		Info("abcdefghijklmnopqrstuvwxyz")
 
 	s := strings.TrimSpace(buf.String())


### PR DESCRIPTION
## Description
This change adds an optional `MaxFieldLength` parameter to the apex log handler. If set, then:

1. A message field longer than this will be trimmed
2. Any string data values long than this will be trimmed
3. Any non-string data values that are longer than this when serialized to json will be dropped

The change should be a no-op if the field is not set.

The motivation here is that compute-service, which uses this handler, is running into issues with very long log messages that they'd like to trim everywhere.

## Testing
Ran `go test ./apex/`, verified that tests passed.